### PR TITLE
this is a minor fix

### DIFF
--- a/api/ivy.xml
+++ b/api/ivy.xml
@@ -30,6 +30,8 @@
 		<dependency org="pentaho" name="pentaho-xul-core"           rev="${dependency.pentaho-xul.revision}"                 changing="true" transitive="false"/>
 		<dependency org="pentaho" name="pentaho-database-model"     rev="${dependency.pentaho-database-model.revision}"               changing="true" transitive="false"/>
 
+		<dependency org="junit" name="junit" rev="4.12" conf="test->default"/>
+
         <override org="pentaho-kettle" rev="${dependency.kettle.revision}" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
	- ant test on platform-api fails with missing jar
	- nevertheless, platform-api does not have unit tests
	- this is just to fix the 'missing jar' error