### PR TITLE
fix for PasswordEncoder

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
+++ b/repository/src/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
@@ -98,8 +98,7 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
 
   @Override
   public boolean matches( CharSequence rawPassword, String encodedPassword ) {
-    // TODO Auto-generated method stub
-    return false;
+    return isPasswordValid( encodedPassword, ( rawPassword != null ? rawPassword.toString() : "" ), null );
   }
 
 }


### PR DESCRIPTION
	- new spring security calls for matches() method, instead of the ( deprecated ) isPasswordValid()