### PR TITLE
- in applicationContext-spring-security, switched from SimpleUrlAuthSucc...

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -201,7 +201,7 @@
     </property>
 
     <property name="authenticationSuccessHandler">
-      <bean class="org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler">
+      <bean class="org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler">
         <property name="defaultTargetUrl" value="/Home" />
       </bean>
     </property>

--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
@@ -21,6 +21,7 @@
     import="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter,
             org.springframework.security.web.savedrequest.SavedRequest,
             org.springframework.security.core.AuthenticationException,
+            org.springframework.security.web.context.HttpSessionSecurityContextRepository,
             org.pentaho.platform.uifoundation.component.HtmlComponent,
             org.pentaho.platform.engine.core.system.PentahoSystem,
             org.pentaho.platform.util.messages.LocaleHelper,
@@ -41,7 +42,7 @@
 
   private List<String> send401RequestList;
 
-  public final String SPRING_SECURITY_SAVED_REQUEST_KEY = "SPRING_SECURITY_SAVED_REQUEST_KEY";
+  public final String SPRING_SECURITY_SAVED_REQUEST_KEY = HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
 
   public void jspInit() {
     // super.jspInit();

--- a/core/src/org/pentaho/platform/engine/security/PentahoSecurityContextHolderStrategy.java
+++ b/core/src/org/pentaho/platform/engine/security/PentahoSecurityContextHolderStrategy.java
@@ -22,7 +22,7 @@ public class PentahoSecurityContextHolderStrategy implements SecurityContextHold
 
   public SecurityContext getContext() {
     if ( context.get() == null ) {
-      context.set( new PentahoSecurityContextImpl() );
+      context.set( createEmptyContext() );
     }
 
     return (SecurityContext) context.get();
@@ -63,7 +63,7 @@ public class PentahoSecurityContextHolderStrategy implements SecurityContextHold
 
   @Override
   public SecurityContext createEmptyContext() {
-    return getContext();
+    return new PentahoSecurityContextImpl();
   }
 
 


### PR DESCRIPTION
...essHandler to SavedRequestAwareAuthSuccessHandler

- in PUCLogin.jsp, switched from a hardcoded string to the constant key
- in PentahoSecurityContextHolderStrategy the createEmptyContext() is now properly *always* returning an empty SecurityContext