### PR TITLE
- with org.springframework.security at DEBUG level, noticed some errors ...

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
@@ -29,7 +29,7 @@
     </pen:publish>
   </bean>
 
-  <bean id="authenticator" class="org.springframework.security.authentication.ldap.authenticator.BindAuthenticator">
+  <bean id="authenticator" class="org.springframework.security.ldap.authentication.BindAuthenticator">
     <constructor-arg>
       <ref bean="contextSource" />
     </constructor-arg>
@@ -56,7 +56,7 @@
 
   <!-- be sure to escape ampersands -->
   <bean id="populator"
-        class="org.springframework.security.ldap.populator.DefaultLdapAuthoritiesPopulator">
+        class="org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator">
     <constructor-arg index="0">
       <ref bean="contextSource" />
     </constructor-arg>

--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-superuser.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-superuser.xml
@@ -43,6 +43,6 @@
 
 
 	<bean id="superPasswordEncoder"
-		class="org.springframework.security.providers.encoding.Md5PasswordEncoder" />
+		class="org.springframework.security.authentication.encoding.Md5PasswordEncoder" />
 
 </beans>

--- a/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
@@ -47,8 +47,6 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   <bean id="contentrepo" class="org.pentaho.platform.repository2.unified.fileio.RepositoryContentOutputHandler"
         scope="session"/>
   <bean id="vfs-ftp" class="org.pentaho.platform.plugin.outputs.ApacheVFSOutputHandler" scope="session"/>
-  <bean id="IAclPublisher" class="org.pentaho.platform.engine.security.acls.AclPublisher" scope="singleton"/>
-  <bean id="IAclVoter" class="org.pentaho.platform.engine.security.acls.voter.PentahoBasicAclVoter" scope="singleton"/>
   <bean id="IVersionHelper" class="org.pentaho.platform.util.VersionHelper" scope="singleton"/>
   <bean id="ICacheManager" class="org.pentaho.platform.plugin.services.cache.CacheManager" scope="singleton"/>
   <bean id="IScheduler2" class="org.pentaho.platform.scheduler2.quartz.QuartzScheduler" scope="singleton">


### PR DESCRIPTION
...that were being masked and fixed them ( errors due to new class mappings for spring upgrade )

	- also, in pentahoObjects.spring.xml, we were referencing 2 Pentaho Acl objects that no longer exist