### PR TITLE
Switching from custom 'org.pentaho.platform.engine.security.PentahoSecur...

### DIFF
--- a/core/src/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -84,7 +84,7 @@ public class PentahoSystem {
 
   public static final boolean ignored = false; // used to suppress compiler
   private static final String securityContextHolderStrategy =
-      "org.pentaho.platform.engine.security.PentahoSecurityContextHolderStrategy";
+      SecurityContextHolder.MODE_INHERITABLETHREADLOCAL;
 
   public static int loggingLevel = ILogger.ERROR;
 


### PR DESCRIPTION
...ityContextHolderStrategy' to Spring's 'SecurityContextHolder.MODE_INHERITABLETHREADLOCAL'

	- PentahoSecurityContextHolderStrategy is a custom pentaho implementation of org.springframework.security.context.InheritableThreadLocalSecurityContextHolderStrategy, but it was causing issues
	- SecurityContextHolder.MODE_INHERITABLETHREADLOCAL *is* org.springframework.security.context.InheritableThreadLocalSecurityContextHolderStrategy