### PR TITLE
fix for PentahoSessionHolder.getSession()

### DIFF
--- a/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
+++ b/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
@@ -27,6 +27,7 @@ import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
+import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
@@ -65,7 +66,7 @@ public class PentahoAuthenticationSuccessListener implements ApplicationListener
   // =========================================================================================================
 
   public void onApplicationEvent( final ApplicationEvent event ) {
-    if ( event instanceof AuthenticationSuccessEvent ) {
+    if ( event instanceof AuthenticationSuccessEvent || event instanceof InteractiveAuthenticationSuccessEvent ) {
       logger.debug( "received " + event.getClass().getSimpleName() ); //$NON-NLS-1$
       logger.debug( "synchronizing current IPentahoSession with SecurityContext" ); //$NON-NLS-1$
       try {


### PR DESCRIPTION
	- new auth event is of type InteractiveAuthenticationSuccessEvent	- PentahoAuthenticationSuccessListener is the place where PentahoSession is synced with the user that has just logged in